### PR TITLE
Remove optional on description

### DIFF
--- a/ui/src/components/Modal/index.tsx
+++ b/ui/src/components/Modal/index.tsx
@@ -2,7 +2,7 @@ import { Wrapper, Buttons } from './styles';
 
 interface ModalProps {
   title: string;
-  description?: string;
+  description: string;
   accept: string;
   decline: string;
   handleAccept: () => Promise<void> | void;


### PR DESCRIPTION
When building it throws 
![image](https://user-images.githubusercontent.com/4263996/112769589-2ccf4100-9022-11eb-800f-e8904ab6b149.png)

Removing it fixes the build error. I personally don't have a lot of experience with typescript and react so there is probably a better way to fix this.
