### PR TITLE
Fix/initial exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ typescript/yarn.lock
 ui/node_modules/
 ui/build/
 ui/yarn.lock
+.idea/

--- a/typescript/src/client/index.ts
+++ b/typescript/src/client/index.ts
@@ -387,41 +387,32 @@ function setPedAppearance(ped: number, appearance: Omit<PedAppearance, 'model'>)
   }
 }
 
-function init(): void {
-  Customization.loadModule();
+Customization.loadModule();
 
-  // Getters
-  exp('getPedModel', getPedModel);
-  exp('getPedComponents', getPedComponents);
-  exp('getPedProps', getPedProps);
-  exp('getPedHeadBlend', getPedHeadBlend);
-  exp('getPedFaceFeatures', getPedFaceFeatures);
-  exp('getPedHeadOverlays', getPedHeadOverlays);
-  exp('getPedHair', getPedHair);
+// Getters
+exp('getPedModel', getPedModel);
+exp('getPedComponents', getPedComponents);
+exp('getPedProps', getPedProps);
+exp('getPedHeadBlend', getPedHeadBlend);
+exp('getPedFaceFeatures', getPedFaceFeatures);
+exp('getPedHeadOverlays', getPedHeadOverlays);
+exp('getPedHair', getPedHair);
 
-  exp('getPedAppearance', getPedAppearance);
+exp('getPedAppearance', getPedAppearance);
 
-  // Setters
-  exp('setPlayerModel', setPlayerModel);
-  exp('setPedHeadBlend', setPedHeadBlend);
-  exp('setPedFaceFeatures', setPedFaceFeatures);
-  exp('setPedHeadOverlays', setPedHeadOverlays);
-  exp('setPedHair', setPedHair);
-  exp('setPedEyeColor', setPedEyeColor);
+// Setters
+exp('setPlayerModel', setPlayerModel);
+exp('setPedHeadBlend', setPedHeadBlend);
+exp('setPedFaceFeatures', setPedFaceFeatures);
+exp('setPedHeadOverlays', setPedHeadOverlays);
+exp('setPedHair', setPedHair);
+exp('setPedEyeColor', setPedEyeColor);
 
-  exp('setPedComponent', setPedComponent);
-  exp('setPedComponents', setPedComponents);
+exp('setPedComponent', setPedComponent);
+exp('setPedComponents', setPedComponents);
 
-  exp('setPedProp', setPedProp);
-  exp('setPedProps', setPedProps);
+exp('setPedProp', setPedProp);
+exp('setPedProps', setPedProps);
 
-  exp('setPlayerAppearance', setPlayerAppearance);
-  exp('setPedAppearance', setPedAppearance);
-}
-
-on('onClientResourceStart', resourceName => {
-  if (GetCurrentResourceName() != resourceName) {
-    return;
-  }
-  init();
-});
+exp('setPlayerAppearance', setPlayerAppearance);
+exp('setPedAppearance', setPedAppearance);


### PR DESCRIPTION
The reason for this is when the script is first run, the exports will now be available immediately. Running them after `clientresourcestart` appeared to be too late for the other resource to be able to make use of the exports